### PR TITLE
changed location of libxml module for apache to load

### DIFF
--- a/puppet-etc/modules/byzpi/templates/etc/apache2/conf.d/proxy-html.conf
+++ b/puppet-etc/modules/byzpi/templates/etc/apache2/conf.d/proxy-html.conf
@@ -100,7 +100,7 @@ ProxyPass /olsrd/ http://localhost:9090/
 ProxyPassReverse /olsrd/ http://localhost:9090/
 
 # Groundstation.
-LoadFile libxml2.so.2.8.0
+LoadFile /usr/lib/arm-linux-gnueabihf/libxml2.so
 ProxyPass /microblog/ http://localhost:9005/
 ProxyHTMLURLMap http://localhost:9005/ /microblog/
 <location /microblog/ >


### PR DESCRIPTION
In issue #17, you mentioned that libxml2.so was renamed to include the current version number. Raspbian keeps some lib files in /usr/lib/arm-linux-gnueabihf/, one of them being libxml2.so which is a symlink to libxml2.so.2.8.0.
